### PR TITLE
ci: gate the test suite on the diff instead of the branch name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+# The diff decides whether the suite runs, never the branch name: a conventional-commits type says
+# what a change is for and nothing about what it touched, so a `chore/`, `ci/` or `docs/` branch
+# carrying code has to be tested like any other. The `paths-ignore` below is what skips pure prose.
 on:
   push:
     branches:
@@ -20,7 +23,6 @@ permissions: write-all
 
 jobs:
   run_tests:
-    if: ${{ !(startsWith(github.head_ref, 'chore/') || startsWith(github.head_ref, 'ci/') || startsWith(github.head_ref, 'docs/')) }}
     runs-on: ubuntu-latest
     # container: catthehacker/ubuntu:act-20.04  # Uncomment it if you use it on Gitea
 


### PR DESCRIPTION
`Run Tests` decided from the head branch name whether it ran at all:

```yaml
if: ${{ !(startsWith(github.head_ref, 'chore/') || startsWith(github.head_ref, 'ci/') || startsWith(github.head_ref, 'docs/')) }}
```

A conventional-commits type states what a change is *for*. It says nothing about what the change *touched*, so it cannot answer the question the gate is asking, and `chore/`, `ci/` and `docs/` branches routinely carry code. Renaming the branch is not available either: the labeler reads that same prefix to type the PR.

The trigger's `paths-ignore: "**/*.md"` already asks the right question and stays, so a pull request that moves nothing but prose still skips the suite. The `if:` is deleted so that filter gets to answer.

Same fix as Mai0313/discordbot#552, where this gate had already let a red default branch through unnoticed.

---

Opened-by: Claude Opus 5
